### PR TITLE
Avoid Compile time warnings after assert statements

### DIFF
--- a/imageLayer.c
+++ b/imageLayer.c
@@ -32,6 +32,8 @@
 #include "image.h"
 #include "imageLayer.h"
 
+#define _unused(x) ((void)(x))
+
 //-------------------------------------------------------------------------
 
 void
@@ -78,6 +80,7 @@ createResourceImageLayer(
                                              il->image.buffer,
                                              &(il->bmpRect));
     assert(result == 0);
+    _unused(result); // Avoid compile time warning
 }
 
 //-------------------------------------------------------------------------
@@ -176,7 +179,7 @@ changeSourceImageLayer(
                                                il->element,
                                                il->resource);
     assert(result == 0);
-
+    _unused(result); // Avoid compile time warning
 }
 
 //-------------------------------------------------------------------------
@@ -202,7 +205,7 @@ changeSourceAndUpdateImageLayer(
 
     result = vc_dispmanx_update_submit_sync(update);
     assert(result == 0);
-
+    _unused(result); // Avoid compile time warning
 }
 
 //-------------------------------------------------------------------------
@@ -231,6 +234,7 @@ moveImageLayer(
                                           0,
                                           DISPMANX_NO_ROTATE);
     assert(result == 0);
+    _unused(result); // Avoid compile time warning
 }
 
 //-------------------------------------------------------------------------
@@ -252,7 +256,7 @@ destroyImageLayer(
 
     result = vc_dispmanx_resource_delete(il->resource);
     assert(result == 0);
-
+    _unused(result); // Avoid compile time warning
     //---------------------------------------------------------------------
 
     destroyImage(&(il->image));


### PR DESCRIPTION
The use of assert(result) is good, but if result is not used elsewhere we get compile time warnings of "variable ‘result’ set but not used".  Using result in a dummy function avoids these warnings.